### PR TITLE
add error message when no OPENAI key is set

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -263,6 +263,10 @@ const completerFunc = (linePartial, callback) => {
   });
 };
 
+if (!process.env.OPENAI_API_KEY) {
+  return console.error(`---------> You need to set an authorization token with OPENAI_API_KEY env`);
+}
+
 // Create REPL instance
 const gptCli = repl.start({
   prompt: "gpt-console> ",


### PR DESCRIPTION
Before when no OPEN AI key was set it would try and do the request and fail with a big loader and message. Now there is a simple clean error message 